### PR TITLE
Split HTTPStore url list into search and rewards urls

### DIFF
--- a/worker/store/store.go
+++ b/worker/store/store.go
@@ -6,17 +6,14 @@ import (
 	"github.com/figment-networks/indexing-engine/structs"
 )
 
-type RewardStoreCaller interface {
+type StoreCaller interface {
+	GetSearchSession(ctx context.Context) (SearchStore, error)
 	GetRewardsSession(ctx context.Context) (RewardStore, error)
 }
 
 type RewardStore interface {
 	StoreClaimedRewards(ctx context.Context, rwds []structs.ClaimedReward) error
 	StoreUnclaimedRewards(ctx context.Context, rwds []structs.UnclaimedReward) error
-}
-
-type SearchStoreCaller interface {
-	GetSearchSession(ctx context.Context) (SearchStore, error)
 }
 
 type SearchStore interface {

--- a/worker/store/transport/http/http.go
+++ b/worker/store/transport/http/http.go
@@ -86,12 +86,15 @@ func (s *HTTPStore) GetSearchSession(ctx context.Context) (store.SearchStore, er
 	}}, nil
 }
 
+// HTTPStoreSession contains common logic for Store structs (SearchStore and RewardStore).
 type HTTPStoreSession struct {
 	cli *http.Client
 	url string
 }
 
+// call sends the JSON RPC request with the given `in` data.
 func (s *HTTPStoreSession) call(ctx context.Context, name string, in interface{}) error {
+	// create the JSON request data
 	buff := new(bytes.Buffer)
 	enc := json.NewEncoder(buff)
 	buff.WriteString(`{"jsonrpc":"2.0","id":1,"method":"` + name + `","params":`)
@@ -100,6 +103,7 @@ func (s *HTTPStoreSession) call(ctx context.Context, name string, in interface{}
 	}
 	buff.WriteString(`}`)
 
+	// send the request
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, buff)
 	if err != nil {
 		return err

--- a/worker/store/transport/http/http.go
+++ b/worker/store/transport/http/http.go
@@ -94,7 +94,7 @@ type HTTPStoreSession struct {
 func (s *HTTPStoreSession) call(ctx context.Context, name string, in interface{}) error {
 	buff := new(bytes.Buffer)
 	enc := json.NewEncoder(buff)
-	buff.WriteString(`{"jsonrpc": "2.0", "id": 1, "method": "` + name + `", "params": `)
+	buff.WriteString(`{"jsonrpc":"2.0","id":1,"method":"` + name + `","params":`)
 	if err := enc.Encode(in); err != nil {
 		return err
 	}

--- a/worker/store/transport/http/http.go
+++ b/worker/store/transport/http/http.go
@@ -12,6 +12,41 @@ import (
 	"github.com/figment-networks/indexing-engine/worker/store"
 )
 
+// roundRobin can be used to get the next url from a list of given urls,
+// starting with the first.
+type roundRobin struct {
+	urls []string
+	next int
+	len  int
+	lock sync.Mutex
+}
+
+func newRoundRobin(urls []string) *roundRobin {
+	return &roundRobin{
+		urls: urls,
+		len:  len(urls),
+	}
+}
+
+// getNext returns the next url in the list.
+func (r *roundRobin) getNext() string {
+	r.lock.Lock()
+
+	// get the current url
+	url := r.urls[r.next]
+
+	// increase the index
+	if r.next < r.len-1 {
+		r.next++
+	} else {
+		r.next = 0
+	}
+
+	r.lock.Unlock()
+
+	return url
+}
+
 type HTTPStore struct {
 	cli  *http.Client
 	urls []string

--- a/worker/store/transport/http/http_test.go
+++ b/worker/store/transport/http/http_test.go
@@ -1,0 +1,22 @@
+package http
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundRobin(t *testing.T) {
+	t.Run("round robin next url", func(t *testing.T) {
+
+		urls := []string{"url1", "url2", "url3", "url4"}
+		rr := newRoundRobin(urls)
+
+		// run several rounds
+		for i := 1; i <= 3; i++ {
+			for ii := 0; ii < len(urls); ii++ {
+				require.Equal(t, urls[ii], rr.getNext())
+			}
+		}
+	})
+}


### PR DESCRIPTION
`HTTPStore` used to contain a list of urls that would be used for making calls to both the search and rewards services.
Split the list into 2, one for search, one for rewards. This means a breaking change for the constructor. The workers I identified that would need to be updated are:
* cosmos
* kava
* polkadot
* celo

Missing anything?
Merged the 2 `StoreCaller` interfaces.
Also added a few comments here and there.